### PR TITLE
fix non-root deployments

### DIFF
--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -16,18 +16,21 @@ This program is available under Apache License Version 2.0, available at https:/
 
     <!--
       The `<base>` tag below is present to support two advanced deployment options:
-      1) Differential serving. 2) Serving from a non-root path.
+      1) Differential serving. 2) Serving from a non-root path (e.g., with URLs
+      like `my.domain/vaadin-elements-app/` and `my.domain/vaadin-elements-app/employee-list`)
+
       Instead of manually editing the `<base>` tag yourself, you should generally either:
       a) Add a `basePath` property to the build configuration in your `polymer.json`.
       b) Use the `--base-path` command-line option for `polymer build`.
-      Note: If you intend to serve from a non-root path, see [polymer-root-path] below.
+
+      The `basePath` property should include leading and trailing slashes (e.g., `/vaadin-elements-app/`).
     -->
     <base href="/">
 
-    <link rel="icon" href="/images/favicon.ico">
+    <link rel="icon" href="images/favicon.ico">
 
     <!-- Web App Manifest -->
-    <link rel="manifest" href="/manifest.json">
+    <link rel="manifest" href="manifest.json">
 
     <!-- See https://goo.gl/qRE0vM -->
     <meta name="theme-color" content="#1576f3">
@@ -42,31 +45,19 @@ This program is available under Apache License Version 2.0, available at https:/
     <meta name="apple-mobile-web-app-title" content="<%= name %>">
 
     <!-- Homescreen icons -->
-    <link rel="apple-touch-icon" href="/images/manifest/icon-48x48.png">
-    <link rel="apple-touch-icon" sizes="72x72" href="/images/manifest/icon-72x72.png">
-    <link rel="apple-touch-icon" sizes="96x96" href="/images/manifest/icon-96x96.png">
-    <link rel="apple-touch-icon" sizes="144x144" href="/images/manifest/icon-144x144.png">
-    <link rel="apple-touch-icon" sizes="192x192" href="/images/manifest/icon-192x192.png">
+    <link rel="apple-touch-icon" href="images/manifest/icon-48x48.png">
+    <link rel="apple-touch-icon" sizes="72x72" href="images/manifest/icon-72x72.png">
+    <link rel="apple-touch-icon" sizes="96x96" href="images/manifest/icon-96x96.png">
+    <link rel="apple-touch-icon" sizes="144x144" href="images/manifest/icon-144x144.png">
+    <link rel="apple-touch-icon" sizes="192x192" href="images/manifest/icon-192x192.png">
 
     <!-- Tile icon for Windows 8 (144x144 + tile color) -->
-    <meta name="msapplication-TileImage" content="/images/manifest/icon-144x144.png">
+    <meta name="msapplication-TileImage" content="images/manifest/icon-144x144.png">
     <meta name="msapplication-TileColor" content="#1576f3">
     <meta name="msapplication-tap-highlight" content="no">
 
     <script>
-      /**
-      * [polymer-root-path]
-      *
-      * By default, we set `Polymer.rootPath` to the server root path (`/`).
-      * Leave this line unchanged if you intend to serve your app from the root
-      * path (e.g., with URLs like `my.domain/` and `my.domain/employee-list`).
-      *
-      * If you intend to serve your app from a non-root path (e.g., with URLs
-      * like `my.domain/<%= elementName %>/` and `my.domain/<%= elementName %>/employee-list`), edit this line
-      * to indicate the path from which you'll be serving, including leading
-      * and trailing slashes (e.g., `/<%= elementName %>/`).
-      */
-      window.Polymer = {rootPath: '/'};
+      window.Polymer = { rootPath: document.querySelector('base').getAttribute('href') };
       // Load and register pre-caching Service Worker
       if ('serviceWorker' in navigator) {
         window.addEventListener('load', function() {

--- a/app/templates/src/employee-list.html
+++ b/app/templates/src/employee-list.html
@@ -22,7 +22,7 @@
 
     <iron-ajax
       auto
-      url="/employees.json"
+      url="employees.json"
       handle-as="json"
       last-response="{{_employees}}"></iron-ajax>
 

--- a/app/templates/src/vaadin-elements-app.html
+++ b/app/templates/src/vaadin-elements-app.html
@@ -68,9 +68,9 @@
       <app-drawer id="drawer" slot="drawer" swipe-open="[[narrow]]">
         <app-toolbar>Menu</app-toolbar>
         <iron-selector selected="[[page]]" attr-for-selected="name" class="drawer-list" role="navigation">
-          <a name="employee-list" href="/employee-list">Employee list</a>
-          <a name="employee-sales" href="/employee-sales">Employee sales</a>
-          <a name="employee-new" href="/employee-new">New employee</a>
+          <a name="employee-list" href="employee-list">Employee list</a>
+          <a name="employee-sales" href="employee-sales">Employee sales</a>
+          <a name="employee-new" href="employee-new">New employee</a>
         </iron-selector>
       </app-drawer>
 

--- a/app/templates/test/employee-list.html
+++ b/app/templates/test/employee-list.html
@@ -3,13 +3,14 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, minimum-scale=1, initial-scale=1, user-scalable=yes">
+    <base href="/">
 
     <title>employee-list</title>
 
-    <script src="../bower_components/web-component-tester/browser.js"></script>
+    <script src="bower_components/web-component-tester/browser.js"></script>
 
     <!-- Import the element to test -->
-    <link rel="import" href="../src/employee-list.html">
+    <link rel="import" href="src/employee-list.html">
   </head>
   <body>
     <test-fixture id="basic">

--- a/app/templates/test/employee-new.html
+++ b/app/templates/test/employee-new.html
@@ -3,13 +3,14 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, minimum-scale=1, initial-scale=1, user-scalable=yes">
+    <base href="/">
 
     <title>employee-new</title>
 
-    <script src="../bower_components/web-component-tester/browser.js"></script>
+    <script src="bower_components/web-component-tester/browser.js"></script>
 
     <!-- Import the element to test -->
-    <link rel="import" href="../src/employee-new.html">
+    <link rel="import" href="src/employee-new.html">
   </head>
   <body>
     <test-fixture id="basic">

--- a/app/templates/test/employee-sales.html
+++ b/app/templates/test/employee-sales.html
@@ -3,13 +3,14 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, minimum-scale=1, initial-scale=1, user-scalable=yes">
+    <base href="/">
 
     <title>employee-sales</title>
 
-    <script src="../bower_components/web-component-tester/browser.js"></script>
+    <script src="bower_components/web-component-tester/browser.js"></script>
 
     <!-- Import the element to test -->
-    <link rel="import" href="../src/employee-sales.html">
+    <link rel="import" href="src/employee-sales.html">
   </head>
   <body>
     <test-fixture id="basic">


### PR DESCRIPTION
If the app is built for a non-root deployment (e.g. by adding `"autoBasePath": true` into `polymer.json`), polymer build updates the `<base>` tag in `index.html` to the relative deployment path (e.g. to `/es5-bundled/`). Since the base tag has effect only on relative URLs, all URLs in the app should be relative in order to resolve correctly in non-root deployments. Absolute URLs ignore the base tag and would result in incorrect URLs (404).

In addition, this commit removes the need to manually set the global `Polymer.rootPath` property. Instead, the property is automatically initialized with the same value that is set into the `<base>` tag during the build.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/generator-polymer-init-vaadin-elements-app/7)
<!-- Reviewable:end -->
