### PR TITLE
remove explicitly defined fragments for lazy-imports

### DIFF
--- a/app/templates/polymer.json
+++ b/app/templates/polymer.json
@@ -1,12 +1,6 @@
 {
   "entrypoint": "index.html",
   "shell": "src/<%= elementName %>.html",
-  "fragments": [
-    "src/employee-list.html",
-    "src/employee-sales.html",
-    "src/employee-new.html",
-    "src/404.html"
-  ],
   "sources": [
    "src/**/*",
    "images/**/*",


### PR DESCRIPTION
Polymer CLI automatically treats all discovered lazy-imports as fragments. There is no need to define them explicitly.

Apparently, this feature has been there since May 2017 and is quite stable by now. See https://github.com/Polymer/polymer-cli/blob/master/CHANGELOG.md#v0182-05-10-2017

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/generator-polymer-init-vaadin-elements-app/8)
<!-- Reviewable:end -->
