### PR TITLE
fix a typo in the iron-pages fallback selection option

### DIFF
--- a/app/templates/src/vaadin-elements-app.html
+++ b/app/templates/src/vaadin-elements-app.html
@@ -89,7 +89,7 @@
         <iron-pages
             selected="[[page]]"
             attr-for-selected="name"
-            fallback-selection="view404"
+            fallback-selection="404"
             role="main">
           <employee-list name="employee-list"></employee-list>
           <employee-sales name="employee-sales"></employee-sales>


### PR DESCRIPTION
The fallback selection should match the value of the 'name' attribute of the `<app-404>` view inside iron-pages.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/generator-polymer-init-vaadin-elements-app/9)
<!-- Reviewable:end -->
