### PR TITLE
start loading the routing config together with the app shell

### DIFF
--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -74,6 +74,11 @@ This program is available under Apache License Version 2.0, available at https:/
     <!-- Load your application shell -->
     <script type="module" src="./src/app/<%= elementName %>.js"></script>
 
+    <!-- Preload your application routing shell (so that the browser can start
+         downloading it while the app shell is being parsed and rendered).
+         Chech the app shell's ready() method to see how the routing shell is used. -->
+    <script type="module" src="./src/routes/config.js"></script>
+
     <!-- Add any global styles for body, document, etc. -->
     <style>
       body {

--- a/app/templates/src/app/vaadin-elements-app.js
+++ b/app/templates/src/app/vaadin-elements-app.js
@@ -109,6 +109,8 @@ class <%= elementClass %> extends PolymerElement {
       this.__onRouteChanged.bind(this)
     );
 
+    // Keeping the routing code in a separate module and dynamically importing
+    // it _after_ the app shell is ready improves the first page render performance.
     import('../routes/config.js').then(config => {
       const setupRouter = config.default;
       setupRouter(this.shadowRoot.querySelector('main'));


### PR DESCRIPTION
This improves the app performance - no need to wait until the app shell is downloaded, parsed and excuted before the routing config can start loading.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/generator-polymer-init-vaadin-elements-app/16)
<!-- Reviewable:end -->
