### PR TITLE
make the routing bootstrapping code read more like a sentence

### DIFF
--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -74,10 +74,10 @@ This program is available under Apache License Version 2.0, available at https:/
     <!-- Load your application shell -->
     <script type="module" src="./src/app/<%= elementName %>.js"></script>
 
-    <!-- Preload your application routing shell (so that the browser can start
+    <!-- Preload your application routing code (so that the browser can start
          downloading it while the app shell is being parsed and rendered).
-         Chech the app shell's ready() method to see how the routing shell is used. -->
-    <script type="module" src="./src/routes/config.js"></script>
+         Check the app shell's ready() method to see how routing is initialized. -->
+    <script type="module" src="./src/routes/app-routing.js"></script>
 
     <!-- Add any global styles for body, document, etc. -->
     <style>

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -74,6 +74,11 @@ This program is available under Apache License Version 2.0, available at https:/
     <!-- Load your application shell -->
     <script type="module" src="./src/app/<%= elementName %>.js"></script>
 
+    <!-- Preload your application routing shell (so that the browser can start
+         downloading it while the app shell is being parsed and rendered).
+         Chech the app shell's ready() method to see how the routing shell is used. -->
+    <script type="module" src="./src/routes/config.js"></script>
+
     <!-- Add any global styles for body, document, etc. -->
     <style>
       body {

--- a/app/templates/polymer.json
+++ b/app/templates/polymer.json
@@ -4,7 +4,7 @@
   "entrypoint": "index.html",
   "shell": "src/app/<%= elementName %>.js",
   "fragments": [
-    "src/routes/config.js",
+    "src/routes/app-routing.js",
     "src/views/404.js",
     "src/views/employee-list.js",
     "src/views/employee-new.js"

--- a/app/templates/src/app/vaadin-elements-app.js
+++ b/app/templates/src/app/vaadin-elements-app.js
@@ -109,6 +109,8 @@ class <%= elementClass %> extends PolymerElement {
       this.__onRouteChanged.bind(this)
     );
 
+    // Keeping the routing code in a separate module and dynamically importing
+    // it _after_ the app shell is ready improves the first page render performance.
     import('../routes/config.js').then(config => {
       const setupRouter = config.default;
       setupRouter(this.shadowRoot.querySelector('main'));

--- a/app/templates/src/app/vaadin-elements-app.js
+++ b/app/templates/src/app/vaadin-elements-app.js
@@ -111,9 +111,8 @@ class <%= elementClass %> extends PolymerElement {
 
     // Keeping the routing code in a separate module and dynamically importing
     // it _after_ the app shell is ready improves the first page render performance.
-    import('../routes/config.js').then(config => {
-      const setupRouter = config.default;
-      setupRouter(this.shadowRoot.querySelector('main'));
+    import('../routes/app-routing.js').then(routing => {
+      routing.init(this.shadowRoot.querySelector('main'));
     });
   }
 

--- a/app/templates/src/routes/app-routing.js
+++ b/app/templates/src/routes/app-routing.js
@@ -1,7 +1,7 @@
 import { Router } from '@vaadin/router';
 import { EMPLOYEE_LIST, NEW_EMPLOYEE } from './pages.js';
 
-export default function setupRouter(outlet) {
+export function init(outlet) {
   const router = new Router(outlet);
   router.setRoutes([
     {


### PR DESCRIPTION
`import('app-routing.js').then(routing => { routing.init(); })` instead of `import('config.js').then(config => { config.default(); })`

Depends on #16

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/generator-polymer-init-vaadin-elements-app/17)
<!-- Reviewable:end -->
